### PR TITLE
일반 회원 마이페이지 수정

### DIFF
--- a/css/mypage/mypage.css
+++ b/css/mypage/mypage.css
@@ -12,10 +12,18 @@ div.mp-background {
     position: relative;
 }
 
+/* i 태그 속성주기 */
 div.mypage-basic i{
     font-style: normal;
     font-weight: 400;
     font-size: 18px;
+    color: black;
+}
+
+/* a 태그 속성주기 */
+div.mypage-basic a{
+    color:black;
+    text-decoration: none;
 }
 
 div.mypage-basic{
@@ -60,7 +68,6 @@ div.mypage-basic div.mp-user-info span.mp-user-name{
 /* user 이름 아래 menu */
 div.mypage-basic div.mp-user div.mp-user-info div.mp-user-menu {
     margin-top: 40px;
-    /* flex-direction: column; */
 }
 
 div.mypage-basic div.mp-user div.mp-user-info div.mp-user-menu ul li.mp-sub-menu{
@@ -72,13 +79,18 @@ div.mypage-basic div.mp-user div.mp-user-info div.mp-user-menu ul li.mp-sub-menu
 div.mypage-basic div.mp-user div.mp-user-info div.mp-user-menu ul li.mp-sub-menu ul{
     font-size: 16px;
     font-weight: 500;
+    margin-left: -20px;
 }
 
 div.mypage-basic div.mp-user div.mp-user-info div.mp-user-menu ul li.mp-sub-menu ul li{
     margin: 10px 0 10px 0;
 }
 
-    /* user 마이페이지 상단 고정 정보(적립금,쿠폰,팔로우) */
+/* user 마이페이지 상단 고정 정보(적립금,쿠폰,팔로우) */
+section.mp-page div.mypage-basic div.mp-user div.mp-activity{
+    width: 100%;
+}
+
 div.mypage-basic div.mp-user-activity{
     width: 100%;
     height: 6em;
@@ -117,4 +129,111 @@ div.mypage-basic div.mp-user-activity div.row div.col span:hover{
     font-weight: 500;
     color: rgb(0, 175, 133);
     cursor: pointer;
+}
+
+/* 세부 내용 기본 form */
+div.mypage-basic div.mp-user div.mp-activity div.mp-section-form{
+    margin-top: 40px;
+}
+
+div.mypage-basic div.mp-user div.mp-activity div.mp-con-tit {
+    display: flex;
+    justify-content: space-between
+}
+
+div.mypage-basic div.mp-user div.mp-activity div.mp-con-tit span {
+    font-size: 15px;
+    font-weight: 400;
+    color: #777777;
+    margin: 1em;
+}
+
+/* 더보기 */
+div.mypage-basic div.mp-user div.mp-activity div.mp-con-tit div.mp-con-plus a {
+    font-size: 13px;
+    text-decoration: none;
+}
+
+div.mypage-basic div.mp-user div.mp-activity div.mp-con-tit div.mp-con-plus:hover {
+    text-decoration: underline;
+}
+
+/* 주문 내역 테이블 */
+div.mypage-basic div.mp-user div.mp-activity div.mp-table{
+    margin-top:20px;
+    width: 100%;
+    border: 0;
+    border-spacing: 0;
+    border-collapse: collapse;
+    text-align: center;
+}
+
+div.mypage-basic div.mp-user div.mp-activity div.mp-table table{
+    width: 100%;
+    
+}
+
+div.mypage-basic div.mp-user div.mp-activity div.mp-table table thead{
+    height: 3em;
+    background-color: #f7f7f7;
+    border-top: 1px solid #777777;
+}
+
+div.mypage-basic div.mp-user div.mp-activity div.mp-table table tbody tr{
+    border-top: 1px solid #d9d9d9;
+    border-bottom: 1px solid #d9d9d9;
+}
+
+div.mypage-basic div.mp-user div.mp-activity div.mp-table table thead tr th{
+    font-weight: 500;
+}
+
+div.mypage-basic div.mp-user div.mp-activity div.mp-table table tbody tr td{
+    padding: 15px 0;
+}
+
+div.mypage-basic div.mp-user div.mp-activity div.mp-table table tbody tr td strong{
+    color: #00af85;
+}
+
+/* 최근 본 상품 카드 */
+div.mypage-basic div.mp-user div.mp-activity div.mp-recent-box{
+    margin-top: 80px;
+}
+
+div.mp-recent-list div.row div.col div.card{
+    border:none;
+}
+
+div.mp-recent-list div.row div.col div.card div.prodNum{
+    display: none;
+}
+
+div.mp-recent-list div.row div.col div.card div.prodName{
+    font-size: 16px;
+    font-weight: 500;
+}
+
+div.mp-recent-list div.row div.col div.card-body{
+    margin-left: -16px;
+}
+
+div.mp-recent-list div.row div.col div.card div.percentage{
+    float: left;
+    margin-right:10px;
+    color: #f5634b;
+    font-size: 18px;
+    font-weight: 600;
+}
+
+div.mp-recent-list div.row div.col div.card div.prodPrice{
+    float: left;
+    font-size: 18px;
+    font-weight: bold;
+}
+
+div.mp-recent-list div.row div.col div.card div.originPrice{
+    float: left;
+    color: #afafaf;
+    text-decoration: line-through;
 }

--- a/html/mypage/mypage.html
+++ b/html/mypage/mypage.html
@@ -66,45 +66,43 @@
     <section class="mp-page">
         <div class="mp-background"></div>
         <div class="mypage-basic">
-            <!-- 마이페이지 시작 -->
+            <!------------ 마이페이지 START -------------->
             <div class="mp-user">
+                <!-- 유저정보 박스 START -->
                 <div class="mp-user-info">
                     <div class="mp-user-name-level">
                         <span class="mp-user-name">[회원이름]<i>님</i></span>
                         <span class="mp-user-level">회원등급은 [등급]입니다.</span>
                     </div>
-                    <!-- <span class="mp-user-name">[회원이름]<i>님</i></span>
-                    <span class="mp-user-level">[등급]회원</span> -->
                     <div class="mp-user-menu">
-                        <!-- <span>주문정보</span> -->
                         <ul>
-                            <li class="mp-sub-menu"> 주문정보
-                                <ul>
+                            <li class="mp-sub-menu"> | 주문정보
+                                <ul class="mp-sub-side-menu">
                                     <li>주문목록</li>
                                     <li>배송조회</li>
                                 </ul>
                             </li>
-                            <li class="mp-sub-menu"> 혜택관리
-                                <ul>
+                            <li class="mp-sub-menu"> | 혜택관리
+                                <ul class="mp-sub-side-menu">
                                     <li>나의 적립금</li>
                                     <li>나의 쿠폰</li>
                                 </ul>
                             </li>
-                            <li class="mp-sub-menu"> 회원정보
-                                <ul>
+                            <li class="mp-sub-menu"> | 회원정보
+                                <ul class="mp-sub-side-menu">
                                     <li>회원 정보 변경</li>
                                     <li>회원 탈퇴</li>
                                     <li>팔로우 목록</li>
                                 </ul>
                             </li>
-                            <li class="mp-sub-menu"> 나의 문의/리뷰
-                                <ul>
+                            <li class="mp-sub-menu"> | 나의 문의/리뷰
+                                <ul class="mp-sub-side-menu">
                                     <li>상품 문의</li>
                                     <li>상품 리뷰</li>
                                 </ul>
                             </li>
-                            <li class="mp-sub-menu"> 나의 활동
-                                <ul>
+                            <li class="mp-sub-menu"> | 나의 활동
+                                <ul class="mp-sub-side-menu">
                                     <li>내가 쓴 글</li>
                                     <li>내가 쓴 리뷰</li>
                                 </ul>
@@ -112,44 +110,168 @@
                         </ul>
                     </div>
                 </div>
-                <div class="mp-user-activity">
-                    <div class="container">
-                        <div class="row">
-                            <div class="col mp-border">
-                                <div>
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" class="bi bi-p-circle" viewBox="0 0 16 16">
-                                        <path d="M1 8a7 7 0 1 0 14 0A7 7 0 0 0 1 8Zm15 0A8 8 0 1 1 0 8a8 8 0 0 1 16 0ZM5.5 4.002h2.962C10.045 4.002 11 5.104 11 6.586c0 1.494-.967 2.578-2.55 2.578H6.784V12H5.5V4.002Zm2.77 4.072c.893 0 1.419-.545 1.419-1.488s-.526-1.482-1.42-1.482H6.778v2.97H8.27Z"/>
-                                    </svg> 적립금
+                <!-- 유저정보 박스 END -->
+                
+                <!------------ 회원 활동 표시 창 START -------------->
+                <div class="mp-activity">
+                    <div class="mp-user-activity">
+                        <div class="container">
+                            <div class="row">
+                                <div class="col mp-border">
+                                    <div>
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" class="bi bi-p-circle" viewBox="0 0 16 16">
+                                            <path d="M1 8a7 7 0 1 0 14 0A7 7 0 0 0 1 8Zm15 0A8 8 0 1 1 0 8a8 8 0 0 1 16 0ZM5.5 4.002h2.962C10.045 4.002 11 5.104 11 6.586c0 1.494-.967 2.578-2.55 2.578H6.784V12H5.5V4.002Zm2.77 4.072c.893 0 1.419-.545 1.419-1.488s-.526-1.482-1.42-1.482H6.778v2.97H8.27Z"/>
+                                        </svg> 적립금
+                                    </div>
+                                    <span class="mp-user-point">얼마
+                                        <i>원</i>
+                                    </span>
                                 </div>
-                                <span class="mp-user-point">얼마
-                                    <i>원</i>
-                                </span>
-                            </div>
-                            <div class="col mp-border">
-                                <div>
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-ticket-detailed" viewBox="0 0 16 16">
-                                    <path d="M4 5.5a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5Zm0 5a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5ZM5 7a1 1 0 0 0 0 2h6a1 1 0 1 0 0-2H5Z"/>
-                                    <path d="M0 4.5A1.5 1.5 0 0 1 1.5 3h13A1.5 1.5 0 0 1 16 4.5V6a.5.5 0 0 1-.5.5 1.5 1.5 0 0 0 0 3 .5.5 0 0 1 .5.5v1.5a1.5 1.5 0 0 1-1.5 1.5h-13A1.5 1.5 0 0 1 0 11.5V10a.5.5 0 0 1 .5-.5 1.5 1.5 0 1 0 0-3A.5.5 0 0 1 0 6V4.5ZM1.5 4a.5.5 0 0 0-.5.5v1.05a2.5 2.5 0 0 1 0 4.9v1.05a.5.5 0 0 0 .5.5h13a.5.5 0 0 0 .5-.5v-1.05a2.5 2.5 0 0 1 0-4.9V4.5a.5.5 0 0 0-.5-.5h-13Z"/>
-                                    </svg> 쿠폰
+                                <div class="col mp-border">
+                                    <div>
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-ticket-detailed" viewBox="0 0 16 16">
+                                        <path d="M4 5.5a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5Zm0 5a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5ZM5 7a1 1 0 0 0 0 2h6a1 1 0 1 0 0-2H5Z"/>
+                                        <path d="M0 4.5A1.5 1.5 0 0 1 1.5 3h13A1.5 1.5 0 0 1 16 4.5V6a.5.5 0 0 1-.5.5 1.5 1.5 0 0 0 0 3 .5.5 0 0 1 .5.5v1.5a1.5 1.5 0 0 1-1.5 1.5h-13A1.5 1.5 0 0 1 0 11.5V10a.5.5 0 0 1 .5-.5 1.5 1.5 0 1 0 0-3A.5.5 0 0 1 0 6V4.5ZM1.5 4a.5.5 0 0 0-.5.5v1.05a2.5 2.5 0 0 1 0 4.9v1.05a.5.5 0 0 0 .5.5h13a.5.5 0 0 0 .5-.5v-1.05a2.5 2.5 0 0 1 0-4.9V4.5a.5.5 0 0 0-.5-.5h-13Z"/>
+                                        </svg> 쿠폰
+                                    </div>
+                                    <span class="mp-user-coupon">몇
+                                        <i>장</i>
+                                    </span>
                                 </div>
-                                <span class="mp-user-coupon">몇
-                                    <i>장</i>
-                                </span>
-                            </div>
-                            <div class="col">
-                                <div>
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" class="bi bi-shop-window" viewBox="0 0 16 16">
-                                        <path d="M2.97 1.35A1 1 0 0 1 3.73 1h8.54a1 1 0 0 1 .76.35l2.609 3.044A1.5 1.5 0 0 1 16 5.37v.255a2.375 2.375 0 0 1-4.25 1.458A2.371 2.371 0 0 1 9.875 8 2.37 2.37 0 0 1 8 7.083 2.37 2.37 0 0 1 6.125 8a2.37 2.37 0 0 1-1.875-.917A2.375 2.375 0 0 1 0 5.625V5.37a1.5 1.5 0 0 1 .361-.976l2.61-3.045zm1.78 4.275a1.375 1.375 0 0 0 2.75 0 .5.5 0 0 1 1 0 1.375 1.375 0 0 0 2.75 0 .5.5 0 0 1 1 0 1.375 1.375 0 1 0 2.75 0V5.37a.5.5 0 0 0-.12-.325L12.27 2H3.73L1.12 5.045A.5.5 0 0 0 1 5.37v.255a1.375 1.375 0 0 0 2.75 0 .5.5 0 0 1 1 0zM1.5 8.5A.5.5 0 0 1 2 9v6h12V9a.5.5 0 0 1 1 0v6h.5a.5.5 0 0 1 0 1H.5a.5.5 0 0 1 0-1H1V9a.5.5 0 0 1 .5-.5zm2 .5a.5.5 0 0 1 .5.5V13h8V9.5a.5.5 0 0 1 1 0V13a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V9.5a.5.5 0 0 1 .5-.5z"/>
-                                    </svg> 팔로우
+                                <div class="col">
+                                    <div>
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" class="bi bi-shop-window" viewBox="0 0 16 16">
+                                            <path d="M2.97 1.35A1 1 0 0 1 3.73 1h8.54a1 1 0 0 1 .76.35l2.609 3.044A1.5 1.5 0 0 1 16 5.37v.255a2.375 2.375 0 0 1-4.25 1.458A2.371 2.371 0 0 1 9.875 8 2.37 2.37 0 0 1 8 7.083 2.37 2.37 0 0 1 6.125 8a2.37 2.37 0 0 1-1.875-.917A2.375 2.375 0 0 1 0 5.625V5.37a1.5 1.5 0 0 1 .361-.976l2.61-3.045zm1.78 4.275a1.375 1.375 0 0 0 2.75 0 .5.5 0 0 1 1 0 1.375 1.375 0 0 0 2.75 0 .5.5 0 0 1 1 0 1.375 1.375 0 1 0 2.75 0V5.37a.5.5 0 0 0-.12-.325L12.27 2H3.73L1.12 5.045A.5.5 0 0 0 1 5.37v.255a1.375 1.375 0 0 0 2.75 0 .5.5 0 0 1 1 0zM1.5 8.5A.5.5 0 0 1 2 9v6h12V9a.5.5 0 0 1 1 0v6h.5a.5.5 0 0 1 0 1H.5a.5.5 0 0 1 0-1H1V9a.5.5 0 0 1 .5-.5zm2 .5a.5.5 0 0 1 .5.5V13h8V9.5a.5.5 0 0 1 1 0V13a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V9.5a.5.5 0 0 1 .5-.5z"/>
+                                        </svg> 팔로우
+                                    </div>
+                                    <span class="mp-user-follow">몇
+                                        <i>명</i>
+                                    </span>
                                 </div>
-                                <span class="mp-user-follow">몇
-                                    <i>명</i>
-                                </span>
                             </div>
                         </div>
                     </div>
-                </div>
+                    <div class="mp-section-form">
+                        <div class="mp-con-tit">
+                            <h5>최근 주문정보<span>최근 30일 내에 주문하신 내역입니다.</span></h5>
+                            <div class="mp-con-plus">
+                                <a href="#"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-plus" viewBox="0 0 16 16">
+                                    <path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4z"/>
+                                  </svg>더보기</a>
+                            </div>
+                        </div>
+                        <!-- 주문정보 테이블 START -->
+                        <div class="mp-table">
+                            <table>
+                                <colgroup>
+                                    <!-- 날짜/주문번호 -->
+                                    <col style="width:15%">
+                                    <!-- 상품명/옵션 -->
+                                    <col>
+                                    <!-- 상품금액/수량 -->
+                                    <col style="width:15%">
+                                    <!-- 주문상태 -->
+                                    <col style="width:15%">
+                                    <!-- 확인/리뷰 -->
+                                    <col style="width:15%">
+                                </colgroup>
+                                <thead>
+                                    <!-- tr>th*5 -->
+                                    <tr>
+                                        <th>날짜/주문번호</th>
+                                        <th>상품명/옵션</th>
+                                        <th>상품금액/수량</th>
+                                        <th>주문상태</th>
+                                        <th>확인/리뷰</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td rowspan="1">날짜~</td>
+                                        <td>
+                                            <div>
+                                                <span><a href="#"><img>이미지</a></span>
+                                                <div>
+                                                    <a href="#">
+                                                        샐러드 5종 맛보기
+                                                    </a>
+                                                </div>
+                                                <span></span>
+                                            </div>
+
+                                        </td>
+                                        <td>
+                                            <strong>13,600원</strong> / 1개
+                                        </td>
+                                        <td> 결제완료 </td>
+                                        <td> 리뷰 남기기 </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <!-- 주문정보 테이블 END -->
+                        <!-- 최근 본 상품 카드 START -->
+                        <div class="mp-recent-list">
+                            <div class="mp-con-tit mp-recent-box">
+                                <h5>최근 본 상품<span>ㅇㅇㅇ님께서 본 최근 상품입니다.</span></h5>
+                            </div>
+                            <hr>
+                            <div class="row row-cols-1 row-cols-md-4 g-4">
+                                <div class="col">
+                                    <div class="card h-100 rounded-0">
+                                        <img src="../../images/product/prod01.png" class="card-img-top rounded-0" alt="...">
+                                        <div class="prodNum">상품번호</div>
+                                        <div class="prodName">상품명</div>
+                                        <div class="card-body">
+                                            <div class="percentage">할인률</div>
+                                            <div class="prodPrice">할인된 가격</div>
+                                            <div class="originPrice">원가</div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col">
+                                    <div class="card h-100 rounded-0">
+                                        <img src="../../images/product/prod01.png" class="card-img-top rounded-0" alt="...">
+                                        <div class="prodNum">상품번호</div>
+                                        <div class="prodName">상품명</div>
+                                        <div class="card-body">
+                                            <div class="percentage">할인률</div>
+                                            <div class="prodPrice">할인된 가격</div>
+                                            <div class="originPrice">원가</div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col">
+                                    <div class="card h-100 rounded-0">
+                                        <img src="../../images/product/prod01.png" class="card-img-top rounded-0" alt="...">
+                                        <div class="prodNum">상품번호</div>
+                                        <div class="prodName">상품명</div>
+                                        <div class="card-body">
+                                            <div class="percentage">할인률</div>
+                                            <div class="prodPrice">할인된 가격</div>
+                                            <div class="originPrice">원가</div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col">
+                                    <div class="card h-100 rounded-0">
+                                        <img src="../../images/product/prod01.png" class="card-img-top rounded-0" alt="...">
+                                        <div class="prodNum">상품번호</div>
+                                        <div class="prodName">상품명</div>
+                                        <div class="card-body">
+                                            <div class="percentage">할인률</div>
+                                            <div class="prodPrice">할인된 가격</div>
+                                            <div class="originPrice">원가</div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>   
+                <!------------ 회원 활동 표시 창 END -------------->
             </div>
+            <!------------ 마이페이지 END -------------->
         </div>
     </section>
     <!-- section end -->


### PR DESCRIPTION
- 영역을 크게 **왼쪽영역(회원이름/등급, 마이페이지 메뉴들)**, 그리고 **오른쪽영역(적립금/쿠폰/팔로우, 최근 주문목록/최근 본 상품 )** 으로 나눴습니다.
  - 세부적으로 본다면,
    - 1. 회원이름/등급
    - 2. 마이페이지 메뉴들
    - 3. 적립금/쿠폰/팔로우 바
    - 4. 최근 주문목록 / 최근 본 상품 
 이렇게 4개로 나누어집니다.
  - +더보기 를 누르면 기간별로 주문 내역을 조회할 수 있도록 빌드업 되면 좋겠습니다.
  - 마이페이지 메뉴들 디자인을 조금 변경했습니다.
    - 4. 영역은 레퍼런스 디자인과 똑같이 디자인했습니다!
<img width="1781" alt="스크린샷 2023-02-05 오전 1 11 04" src="https://user-images.githubusercontent.com/103922744/216778289-2248e09f-68c7-4b17-8663-f455cc94ee84.png">
